### PR TITLE
Simple plist change. CIF is supposed to be our default with an index …

### DIFF
--- a/Settings/InAppSettings.bundle/Video.plist
+++ b/Settings/InAppSettings.bundle/Video.plist
@@ -80,7 +80,7 @@
 			<array>
 				<integer>0</integer>
 				<integer>1</integer>
-				<string>2</string>
+				<integer>2</integer>
 				<integer>3</integer>
 			</array>
 			<key>DefaultValue</key>


### PR DESCRIPTION
…of 2, but our plist said that 2 was a string rather than a number. By changing that index to a number I was able to fix calls being setup with the wrong resolution.
