### PR TITLE
VATRP-1099 linphone_core_update_call not called if the camera is disa…

### DIFF
--- a/Classes/PhoneMainView.m
+++ b/Classes/PhoneMainView.m
@@ -394,7 +394,7 @@ static RootViewManager *rootViewManagerInstance = nil;
 	if (oldLinphoneOrientation != newRotation) {
 		linphone_core_set_device_rotation([LinphoneManager getLc], newRotation);
 		LinphoneCall *call = linphone_core_get_current_call([LinphoneManager getLc]);
-		if (call && linphone_call_params_video_enabled(linphone_call_get_current_params(call))) {
+		if (call && linphone_call_params_video_enabled(linphone_call_get_current_params(call)) &&          linphone_call_camera_enabled(call)) {
 			// Orientation has changed, must call update call
 			linphone_core_update_call([LinphoneManager getLc], call, NULL);
 		}


### PR DESCRIPTION
…bled during a call. Tested to ensure that this works with the change for VATRP-842 - everything video draws in correct orientation for sender and recipient if the camera is disabled, device rotated, then camera re-enabled.
