### PR TITLE
Vatrp-3876:iOS: Remove the red call decline sip simple message notification

### DIFF
--- a/Classes/InCallViewControllerNew.m
+++ b/Classes/InCallViewControllerNew.m
@@ -254,8 +254,8 @@ typedef NS_ENUM(NSInteger, CallQualityStatus) {
         
         [aAttrString appendAttributedString:vAttrString];
         
-        self.viewCallDeclinedWithMessage.hidden = NO;
-        self.callDeclineMessageLabel.hidden = NO;
+        self.viewCallDeclinedWithMessage.hidden = YES;
+        self.callDeclineMessageLabel.hidden = YES;
         self.callDeclineMessageLabel.attributedText = aAttrString;
         
         [UIView animateKeyframesWithDuration:1.0 delay:0.0 options:UIViewKeyframeAnimationOptionAutoreverse | UIViewKeyframeAnimationOptionRepeat animations:^{


### PR DESCRIPTION
Set hidden red call decline sip simple message notification.
