### PR TITLE
Vatrp-4082:iOS: crash when exporting contacts which have"," symbol in SIP field

### DIFF
--- a/Classes/VSContactsManager.m
+++ b/Classes/VSContactsManager.m
@@ -267,15 +267,22 @@
 - (LinphoneFriend*)createFriendFromName:(NSString*)name withPhoneNumbers:(NSMutableArray*)phoneNumbers andSipURIs:(NSMutableArray*)sipURIs {
     
     LinphoneFriend *newFriend = linphone_core_create_friend([LinphoneManager getLc]);
+    if (newFriend == NULL) {
+        return newFriend;
+    }
     linphone_friend_set_name(newFriend, [name UTF8String]);
     
     const LinphoneAddress *addr = linphone_core_create_address([LinphoneManager getLc], [sipURIs[0] UTF8String]);
-    linphone_friend_set_address(newFriend, addr);
+    if (addr) {
+        linphone_friend_set_address(newFriend, addr);
+    }
     
     if (sipURIs.count > 1) {
         for (int i = 1; i < sipURIs.count; ++i) {
             const LinphoneAddress *addr = linphone_core_create_address([LinphoneManager getLc], [sipURIs[i] UTF8String]);
-            linphone_friend_add_address(newFriend, addr);
+            if (addr) {
+                linphone_friend_add_address(newFriend, addr);
+            }
         }
     }
 
@@ -286,6 +293,16 @@
     LinphoneFriendList *friendList = linphone_core_get_default_friend_list([LinphoneManager getLc]);
     linphone_friend_list_add_friend(friendList, newFriend);
     
+    MSList* addressesList = linphone_friend_get_addresses(newFriend);
+    if (ms_list_size(addressesList) == 0) {
+        return NULL;
+    }
+    
+    if (linphone_friend_get_address(newFriend) == NULL) {
+        return NULL;
+    }
+    
     return newFriend;
 }
+
 @end


### PR DESCRIPTION
Fixed crash during export contact(s) with bad sip address.
